### PR TITLE
whitespace should now be properly removed in endpointURL

### DIFF
--- a/go/cmd/sender.go
+++ b/go/cmd/sender.go
@@ -17,7 +17,7 @@ type slackConfig struct {
 }
 
 func (s *slackConfig) String() string {
-	return strings.Trimspace(s.endpointURL)
+	return strings.TrimSpace(s.endpointURL)
 }
 
 func (s *slackConfig) Set(arg string) error {

--- a/go/cmd/sender.go
+++ b/go/cmd/sender.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type slackConfig struct {
@@ -16,7 +17,7 @@ type slackConfig struct {
 }
 
 func (s *slackConfig) String() string {
-	return s.endpointURL
+	return strings.Trimspace(s.endpointURL)
 }
 
 func (s *slackConfig) Set(arg string) error {


### PR DESCRIPTION
Used the TrimSpace function in the strings packaged to wrap the return value of the slackConfig String function. The function should now return an endpointURL that has leading and trailing whitespace removed.