### PR TITLE
variable name change to avoid confusion and potential scope issues

### DIFF
--- a/python/scrape.py
+++ b/python/scrape.py
@@ -176,12 +176,12 @@ def send_results(results, connection_info):
     GLOBAL_MUTEX.release()
 
 
-def setup_email(email, password, server):
+def setup_email(email_address, password, server):
     global smtp_server
     context = ssl.create_default_context()
     smtp_server = smtplib.SMTP(server, 587)
     smtp_server.starttls(context=context)
-    smtp_server.login(email, password)
+    smtp_server.login(email_address, password)
     return server
 
 


### PR DESCRIPTION
changed argument name in setup_email function from email to email_address to avoid confusion with email global variable declared on line 26.