### PR TITLE
add rules for cisco configs

### DIFF
--- a/go/YaraRules/cisco_configs.yar
+++ b/go/YaraRules/cisco_configs.yar
@@ -1,0 +1,17 @@
+/*
+    This rule will look for Cisco configuration files
+*/
+
+rule cisco_configs
+{
+    meta:
+        author = "@calhandoh"
+    strings:
+        $config_start = "Building configuration..." wide ascii nocase
+        $version = "version" wide ascii nocase
+        $interface = "interface" wide ascii nocase
+        $current_config = "Current configuration" wide ascii nocase
+        $line_break = /!\s/ wide ascii nocase
+    condition:
+        all of them
+}


### PR DESCRIPTION
## Yara rules for Cisco configuration files
- Utilized [Yara 4.2.3](https://github.com/virustotal/yara/releases/tag/v4.2.3) for testing
- Successfully tested against 10+ configuration files found in Cisco documentation and out in the wild
