### PR TITLE
Feature/yararules/ubiquiti

### DIFF
--- a/go/YaraRules/ubiquiti.yar
+++ b/go/YaraRules/ubiquiti.yar
@@ -1,0 +1,18 @@
+/*
+* This rule will look for syntax associated with configuration files routinely seen in Ubiquiti EdgeRouter Series (and likely others) 
+* Tested against default configuration files found at https://github.com/stevejenkins/UBNT-EdgeRouter-Example-Configs
+* as well as other configuration files posted on https://www.reddit.com/r/Ubiquiti
+*/
+
+rule er_configs
+{
+    meta:
+        author = "calhandoh"
+    strings:
+        $firewall = /firewall {[\sa-zA-Z0-9-_{"\/.:$}]*/
+        $interfaces = /interfaces {[\sa-zA-Z0-9-_{"\/.:$}]*/
+        $system = /system {[\sa-zA-Z0-9-_{"\/.:$}]*/
+    condition:
+        // probably overkill as I only observed ($firewall, $interfaces) or ($firewall, $interfaces, $system) configs during testing
+        all of ($firewall, $interfaces) or all of ($interfaces, $system) or all of ($firewall, $system) or all of ($firewall, $interfaces, $system)
+}


### PR DESCRIPTION
## Yara rules for Ubiquiti configuration files
- Utilized [Yara 4.2.3](https://github.com/virustotal/yara/releases/tag/v4.2.3) for testing
- Tested against configurations found on [Github](https://github.com/stevejenkins/UBNT-EdgeRouter-Example-Configs) as well as the [Ubiquti sub-reddit](https://www.reddit.com/r/Ubiquiti/)